### PR TITLE
Schema parser in Scala

### DIFF
--- a/python/liga/registry/model.py
+++ b/python/liga/registry/model.py
@@ -183,8 +183,8 @@ class ModelSpec(ABC):
     def schema(self) -> str:
         """Return the output schema of the model."""
         if "schema" in self._spec:
-            return parse_schema(self._spec["schema"])
-        return parse_schema(self.model_type.schema())
+            return self._spec["schema"]
+        return self.model_type.schema()
 
     @property
     def options(self) -> Dict[str, Any]:

--- a/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
@@ -22,8 +22,15 @@ import ai.eto.rikai.sql.spark.parser.{RikaiExtSqlParser, RikaiSparkSQLParser}
 import com.thoughtworks.enableIf
 import com.thoughtworks.enableIf.classpathMatches
 import org.apache.spark.sql.catalyst.FunctionIdentifier
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFunction}
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo, Literal}
+import org.apache.spark.sql.catalyst.analysis.{
+  UnresolvedAttribute,
+  UnresolvedFunction
+}
+import org.apache.spark.sql.catalyst.expressions.{
+  Expression,
+  ExpressionInfo,
+  Literal
+}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.rikai.RikaiUDTRegistration
@@ -101,7 +108,10 @@ class RikaiSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
       "org.apache.spark.sql.rikai.NDArray",
       "org.apache.spark.sql.rikai.NDArrayType"
     )
-    RikaiUDTRegistration.register("ndarray", org.apache.spark.sql.rikai.NDArrayType)
+    RikaiUDTRegistration.register(
+      "ndarray",
+      org.apache.spark.sql.rikai.NDArrayType
+    )
 
     extensions.injectParser((session, parser) => {
       new RikaiExtSqlParser(

--- a/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
@@ -22,17 +22,12 @@ import ai.eto.rikai.sql.spark.parser.{RikaiExtSqlParser, RikaiSparkSQLParser}
 import com.thoughtworks.enableIf
 import com.thoughtworks.enableIf.classpathMatches
 import org.apache.spark.sql.catalyst.FunctionIdentifier
-import org.apache.spark.sql.catalyst.analysis.{
-  UnresolvedAttribute,
-  UnresolvedFunction
-}
-import org.apache.spark.sql.catalyst.expressions.{
-  Expression,
-  ExpressionInfo,
-  Literal
-}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFunction}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.rikai.RikaiUDTRegistration
+import org.apache.spark.sql.types.UDTRegistration
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 
 private class MlPredictRule(val session: SparkSession)
@@ -102,6 +97,11 @@ private class MlPredictRule(val session: SparkSession)
 class RikaiSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
   override def apply(extensions: SparkSessionExtensions): Unit = {
+    UDTRegistration.register(
+      "org.apache.spark.sql.rikai.NDArray",
+      "org.apache.spark.sql.rikai.NDArrayType"
+    )
+    RikaiUDTRegistration.register("ndarray", org.apache.spark.sql.rikai.NDArrayType)
 
     extensions.injectParser((session, parser) => {
       new RikaiExtSqlParser(
@@ -117,6 +117,5 @@ class RikaiSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectResolutionRule(session => {
       new MlPredictRule(session)
     })
-
   }
 }

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParser.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParser.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Liga authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ai.eto.rikai.sql.spark.parser
 
 import scala.collection.JavaConverters._

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParser.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParser.scala
@@ -1,0 +1,74 @@
+package ai.eto.rikai.sql.spark.parser
+
+import scala.collection.JavaConverters._
+import org.apache.spark.sql.types._
+import ai.eto.rikai.sql.spark.parser.RikaiModelSchemaParser._
+import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
+import org.apache.spark.sql.rikai.RikaiUDTRegistration
+
+class SparkDataTypeVisitor extends RikaiModelSchemaBaseVisitor[DataType] {
+  override def visitUnquotedIdentifier(
+      ctx: UnquotedIdentifierContext
+  ): DataType = {
+    val name = ctx.getText
+    val _SPARK_TYPE_MAPPING = Map(
+      "bool" -> BooleanType,
+      "boolean" -> BooleanType,
+      "byte" -> ByteType,
+      "tinyint" -> ByteType,
+      "short" -> ShortType,
+      "smallint" -> ShortType,
+      "int" -> IntegerType,
+      "long" -> LongType,
+      "bigint" -> LongType,
+      "float" -> FloatType,
+      "double" -> DoubleType,
+      "str" -> StringType,
+      "string" -> StringType,
+      "binary" -> BinaryType
+    )
+    if (_SPARK_TYPE_MAPPING.contains(name)) {
+      _SPARK_TYPE_MAPPING(name)
+    } else if (RikaiUDTRegistration.exists(name)) {
+      RikaiUDTRegistration.getUDT(name).get
+    } else {
+      throw new RuntimeException(s"No such data type ${name}")
+    }
+  }
+
+  override def visitStructType(
+      ctx: StructTypeContext
+  ): StructType = {
+    val fields = ctx
+      .field()
+      .asScala
+      .map { field =>
+        val context =
+          field.asInstanceOf[StructFieldContext]
+        val name = context.name.getText
+        val dataType = this.visitStructField(context)
+        StructField(name, dataType)
+      }
+    StructType(fields)
+  }
+
+  override def visitStructField(ctx: StructFieldContext): DataType = {
+    this.visitChildren(ctx.fieldType())
+  }
+
+  override def visitArrayType(ctx: ArrayTypeContext): DataType = {
+    ArrayType(this.visitChildren(ctx.fieldType()))
+  }
+}
+
+object ModelSchemaParser {
+  def parse_schema(schema: String): DataType = {
+    val lexer = new RikaiModelSchemaLexer(
+      new UpperCaseCharStream(CharStreams.fromString(schema))
+    )
+    val tokens = new CommonTokenStream(lexer)
+    val parser = new RikaiModelSchemaParser(tokens)
+    val visitor = new SparkDataTypeVisitor
+    visitor.visitSchema(parser.schema())
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/rikai/NDArrayType.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/NDArrayType.scala
@@ -71,6 +71,7 @@ private[spark] class NDArrayType extends UserDefinedType[NDArray] {
 
   override def userClass: Class[NDArray] = classOf[NDArray]
 
+  override def typeName: String = "ndarray"
 }
 
 object NDArrayType extends NDArrayType

--- a/src/main/scala/org/apache/spark/sql/rikai/NDArrayType.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/NDArrayType.scala
@@ -73,4 +73,4 @@ private[spark] class NDArrayType extends UserDefinedType[NDArray] {
   override def typeName: String = "ndarray"
 }
 
-object NDArrayType extends NDArrayType
+case object NDArrayType extends NDArrayType

--- a/src/main/scala/org/apache/spark/sql/rikai/NDArrayType.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/NDArrayType.scala
@@ -31,7 +31,6 @@ import org.apache.spark.unsafe.types.UTF8String
   *
   * @param dtype
   */
-@SQLUserDefinedType(udt = classOf[NDArrayType])
 @SerialVersionUID(1L)
 class NDArray(val dtype: String) extends Serializable {
 

--- a/src/main/scala/org/apache/spark/sql/rikai/RikaiUDTRegistration.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/RikaiUDTRegistration.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Liga authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.sql.rikai
 
 import org.apache.spark.internal.Logging
@@ -11,22 +26,15 @@ object RikaiUDTRegistration extends Serializable with Logging {
   def register(schemaName: String, dataType: DataType): Unit = {
     if (schemaMap.contains(schemaName)) {
       logWarning(
-        s"Cannot register UDT for ${schemaName}, which is already registered."
+        s"Cannot register UDT for `${schemaName}`, which is already registered."
       )
     } else {
-      // When register UDT with class name, we can't check if the UDT class is an UserDefinedType,
-      // or not. The check is deferred.
       schemaMap += ((schemaName, dataType))
     }
   }
 
   def exists(schemaName: String): Boolean = schemaMap.contains(schemaName)
 
-  /** Returns the Class of UserDefinedType for the name of a given user class.
-    *
-    * @param schemaName schema name of user class
-    * @return Option value of the Class object of UserDefinedType
-    */
   def getUDT(schemaName: String): Option[DataType] = {
     schemaMap.get(schemaName)
   }

--- a/src/main/scala/org/apache/spark/sql/rikai/RikaiUDTRegistration.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/RikaiUDTRegistration.scala
@@ -1,0 +1,33 @@
+package org.apache.spark.sql.rikai
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.types.{DataType, UserDefinedType}
+
+import scala.collection.mutable
+
+object RikaiUDTRegistration extends Serializable with Logging {
+  private lazy val schemaMap: mutable.Map[String, DataType] = mutable.Map()
+
+  def register(schemaName: String, dataType: DataType): Unit = {
+    if (schemaMap.contains(schemaName)) {
+      logWarning(
+        s"Cannot register UDT for ${schemaName}, which is already registered."
+      )
+    } else {
+      // When register UDT with class name, we can't check if the UDT class is an UserDefinedType,
+      // or not. The check is deferred.
+      schemaMap += ((schemaName, dataType))
+    }
+  }
+
+  def exists(schemaName: String): Boolean = schemaMap.contains(schemaName)
+
+  /** Returns the Class of UserDefinedType for the name of a given user class.
+    *
+    * @param schemaName schema name of user class
+    * @return Option value of the Class object of UserDefinedType
+    */
+  def getUDT(schemaName: String): Option[DataType] = {
+    schemaMap.get(schemaName)
+  }
+}

--- a/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
@@ -1,21 +1,12 @@
 package ai.eto.rikai.sql.spark.parser
 
 import ai.eto.rikai.SparkTestSession
-import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
 import org.apache.spark.sql.rikai.NDArrayType
-import org.apache.spark.sql.types.{ArrayType, BooleanType, DataType, IntegerType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, BooleanType, IntegerType, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 
 class RikaiModelSchemaParserTest extends AnyFunSuite with SparkTestSession {
-  def parse_schema(schema: String): DataType = {
-    val lexer = new RikaiModelSchemaLexer(
-      new UpperCaseCharStream(CharStreams.fromString(schema))
-    )
-    val tokens = new CommonTokenStream(lexer)
-    val parser = new RikaiModelSchemaParser(tokens)
-    val visitor = new SparkDataTypeVisitor
-    visitor.visitSchema(parser.schema())
-  }
+  import ai.eto.rikai.sql.spark.parser.ModelSchemaParser.parse_schema
 
   test("test") {
     assert {

--- a/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
@@ -2,6 +2,7 @@ package ai.eto.rikai.sql.spark.parser
 
 import ai.eto.rikai.SparkTestSession
 import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
+import org.apache.spark.sql.rikai.NDArrayType
 import org.apache.spark.sql.types.{ArrayType, BooleanType, DataType, IntegerType, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -36,6 +37,11 @@ class RikaiModelSchemaParserTest extends AnyFunSuite with SparkTestSession {
       parse_schema("ARRAY<int>") ===
         ArrayType(IntegerType, true)
     }
-    println(parse_schema("ndarray"))
+    assert {
+      parse_schema("ndarray") === NDArrayType
+    }
+    assert {
+      parse_schema("array<ndarray>") === ArrayType(NDArrayType, true)
+    }
   }
 }

--- a/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Liga authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ai.eto.rikai.sql.spark.parser
 
 import ai.eto.rikai.SparkTestSession

--- a/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
@@ -2,7 +2,7 @@ package ai.eto.rikai.sql.spark.parser
 
 import ai.eto.rikai.SparkTestSession
 import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{ArrayType, BooleanType, DataType, IntegerType, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 
 class RikaiModelSchemaParserTest extends AnyFunSuite with SparkTestSession {
@@ -17,11 +17,25 @@ class RikaiModelSchemaParserTest extends AnyFunSuite with SparkTestSession {
   }
 
   test("test") {
-    println(parse_schema("bool").json)
-    println(parse_schema("struct<a:bool, b:int>").json)
-    println(parse_schema("STRUCT<a:bool, b:int>").json)
-    println(parse_schema("array<int>").json)
-    println(parse_schema("ARRAY<int>").json)
-    println(parse_schema("ndarray").json)
+    assert {
+      parse_schema("bool") === BooleanType
+    }
+    assert {
+      parse_schema("struct<a:bool, b:int>") ===
+        StructType(Seq(StructField("a", BooleanType, true), StructField("b", IntegerType, true)))
+    }
+    assert {
+      parse_schema("STRUCT<a:bool, b:int>") ===
+        StructType(Seq(StructField("a", BooleanType, true), StructField("b", IntegerType, true)))
+    }
+    assert {
+      parse_schema("array<int>") ===
+        ArrayType(IntegerType, true)
+    }
+    assert {
+      parse_schema("ARRAY<int>") ===
+        ArrayType(IntegerType, true)
+    }
+    println(parse_schema("ndarray"))
   }
 }

--- a/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiModelSchemaParserTest.scala
@@ -1,0 +1,27 @@
+package ai.eto.rikai.sql.spark.parser
+
+import ai.eto.rikai.SparkTestSession
+import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
+import org.apache.spark.sql.types.DataType
+import org.scalatest.funsuite.AnyFunSuite
+
+class RikaiModelSchemaParserTest extends AnyFunSuite with SparkTestSession {
+  def parse_schema(schema: String): DataType = {
+    val lexer = new RikaiModelSchemaLexer(
+      new UpperCaseCharStream(CharStreams.fromString(schema))
+    )
+    val tokens = new CommonTokenStream(lexer)
+    val parser = new RikaiModelSchemaParser(tokens)
+    val visitor = new SparkDataTypeVisitor
+    visitor.visitSchema(parser.schema())
+  }
+
+  test("test") {
+    println(parse_schema("bool").json)
+    println(parse_schema("struct<a:bool, b:int>").json)
+    println(parse_schema("STRUCT<a:bool, b:int>").json)
+    println(parse_schema("array<int>").json)
+    println(parse_schema("ARRAY<int>").json)
+    println(parse_schema("ndarray").json)
+  }
+}


### PR DESCRIPTION
closes #82 

## Fact
There are two places a Liga schema is written:
1. Python
``` py
class Classifier(SklearnModelType):
    """Classification model type"""

    def schema(self) -> str:
        return "int"

    def predict(self, *args: Any, **kwargs: Any) -> List[int]:
        assert self.model is not None
        assert len(args) == 1
        return self.model.predict(args[0]).tolist()
```
https://github.com/liga-ai/liga/blob/v0.2.0/python/liga/sklearn/models/classifier.py#L24-L33


2. SQL
``` sql
CREATE OR REPLACE MODEL schema_test
RETURNS int
USING 'mlflow:///{registered_model_name}';
```

## Impl Change
Use parse_schema in Scala instead of in Python